### PR TITLE
Remove image mark to restore links

### DIFF
--- a/05_Writing_your_First_Kernels/01 CUDA Basics/README.md
+++ b/05_Writing_your_First_Kernels/01 CUDA Basics/README.md
@@ -103,4 +103,4 @@ CUDA program surface level runtime:
 
 - CUDA parallelism is scalable because their aren’t sequential block run-time dependencies.What I mean here is that you may not run Block 0 & Block 1, then Block 2 & 3… It may be Block 3 & 0, then Block 6 & 1. This means each of these mini “jobs” are solving a subset of the problem independent of the others. Like one piece of the puzzle. As long as all the pieces are assembled in the right place at the end, it works!
 
-> ![How do threads map onto CUDA cores?](https://stackoverflow.com/questions/10460742/how-do-cuda-blocks-warps-threads-map-onto-cuda-cores)
+> [How do threads map onto CUDA cores?](https://stackoverflow.com/questions/10460742/how-do-cuda-blocks-warps-threads-map-onto-cuda-cores)

--- a/05_Writing_your_First_Kernels/02 Kernels/README.md
+++ b/05_Writing_your_First_Kernels/02 Kernels/README.md
@@ -78,8 +78,7 @@ int blockDim = 32; // 32 threads per block
   - no branch prediction
   - significantly less control than CPU architecture gives us more room for more CORES
 
-> Later on in the course (matmul optimization chapter), we will come back to optimzations connected to these special warp ops.
-> ![Warp Level Primitives](https://developer.nvidia.com/blog/using-cuda-warp-level-primitives/)
+> Later on in the course (matmul optimization chapter), we will come back to optimzations connected to these special warp ops. [Warp Level Primitives](https://developer.nvidia.com/blog/using-cuda-warp-level-primitives/)
 
 - https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#thread-hierarchy tells us "There is a limit to the number of threads per block, since all threads of a block are expected to reside on the same streaming multiprocessor core and must share the limited memory resources of that core. On current GPUs, a thread block may contain up to 1024 threads.", indicating 1024 threads per block, 32 threads per warp, and 32 warps per block is our theoretical limit.
 


### PR DESCRIPTION
The links shouldn't contain the "!" symbol. It brakes the MD markdown. 